### PR TITLE
Add missing type specifier

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -30,11 +30,11 @@ type Cmd rune
 
 const (
 	CmdPick   Cmd = 'p'
-	CmdReword     = 'r'
-	CmdEdit       = 'e'
-	CmdSquash     = 's'
-	CmdFixup      = 'f'
-	CmdDrop       = 'd'
+	CmdReword Cmd = 'r'
+	CmdEdit   Cmd = 'e'
+	CmdSquash Cmd = 's'
+	CmdFixup  Cmd = 'f'
+	CmdDrop   Cmd = 'd'
 )
 
 func (cmd Cmd) String() string {


### PR DESCRIPTION
Solves the following warning from linter:
> only the first constant in this group has an explicit type (SA9004)